### PR TITLE
feat(builders): Add fluent request builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,124 +10,97 @@ env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
 jobs:
-  test-ios:
-    name: Test iOS 15
-    runs-on: macos-15
-        
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Show environment
-      run: |
-        echo "=== macOS Version ==="
-        sw_vers
-        echo ""
-        echo "=== Xcode Version ==="
-        xcodebuild -version
-        echo ""
-        echo "=== Swift Version ==="
-        swift --version
-        echo ""
-        echo "=== Available iOS Simulators ==="
-        xcrun simctl list devices available | grep "iPhone"
-      
-    - name: Build for iOS 15
-      run: |
-        swift build -v \
-          -Xswiftc -sdk -Xswiftc $(xcrun --sdk iphonesimulator --show-sdk-path) \
-          -Xswiftc -target -Xswiftc arm64-apple-ios15.0-simulator
-      
-    - name: Run tests on iOS 15
-      run: |
-        xcodebuild test \
-          -scheme NetworkKit \
-          -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=15.0' \
-          -enableCodeCoverage YES \
-          CODE_SIGN_IDENTITY="" \
-          CODE_SIGNING_REQUIRED=NO
 
-  test-macos:
-    name: Test macOS 15
+  # ----------------------------------------
+  # iOS (Xcode-based)
+  # ----------------------------------------
+  ios:
+    name: iOS Tests (Xcode)
     runs-on: macos-15
-        
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Show versions
-      run: |
-        xcodebuild -version
-        swift --version
-      
-    - name: Build for macOS
-      run: swift build -v
-      
-    - name: Run tests on macOS
-      run: swift test -v --enable-code-coverage
-      
-    - name: Generate coverage report
-      run: |
-        xcrun llvm-cov export -format="lcov" \
-          .build/debug/NetworkKitPackageTests.xctest/Contents/MacOS/NetworkKitPackageTests \
-          -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
-      continue-on-error: true
-      
-    - name: Upload coverage
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./coverage.lcov
-        fail_ci_if_error: false
-      continue-on-error: true
 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: List available simulators
+        run: xcrun simctl list devices available
+
+      - name: Build & Test (iOS Simulator)
+        run: |
+          xcodebuild test \
+            -scheme NetworkKit \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0' \
+            -enableCodeCoverage YES \
+            CODE_SIGNING_ALLOWED=NO
+
+  # ----------------------------------------
+  # macOS (Swift Package Manager)
+  # ----------------------------------------
+  macos:
+    name: macOS Tests (SPM)
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Build
+        run: swift build -v
+
+      - name: Test
+        run: swift test -v --enable-code-coverage
+
+      - name: Generate coverage (lcov)
+        run: |
+          xcrun llvm-cov export \
+            -format="lcov" \
+            .build/debug/NetworkKitPackageTests.xctest/Contents/MacOS/NetworkKitPackageTests \
+            -instr-profile .build/debug/codecov/default.profdata \
+            > coverage.lcov
+        continue-on-error: true
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: coverage.lcov
+          fail_ci_if_error: false
+        continue-on-error: true
+
+  # ----------------------------------------
+  # SwiftLint
+  # ----------------------------------------
   lint:
-    name: SwiftLint (Swift 6)
+    name: SwiftLint
     runs-on: macos-15
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Install SwiftLint
-      run: brew install swiftlint
-      
-    - name: Run SwiftLint
-      run: swiftlint lint --strict
 
-  build-all-platforms:
-    name: Build All Apple Platforms
-    runs-on: macos-15
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Build for iOS 15
-      run: |
-        xcodebuild build \
-          -scheme NetworkKit \
-          -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=15.0'
-    
-    - name: Build for macOS 15
-      run: |
-        xcodebuild build \
-          -scheme NetworkKit \
-          -sdk macosx \
-          -destination 'platform=macOS,arch=arm64'
-      continue-on-error: true
+      - uses: actions/checkout@v4
 
-  swift-6-strict-concurrency:
-    name: Swift 6 Strict Concurrency Check
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint --strict
+
+  # ----------------------------------------
+  # Swift 6 Strict Concurrency
+  # ----------------------------------------
+  swift-6-concurrency:
+    name: Swift 6 Strict Concurrency
     runs-on: macos-15
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Build with strict concurrency
-      run: |
-        swift build -v \
-          -Xswiftc -strict-concurrency=complete \
-          -Xswiftc -enable-actor-data-race-checks
+      - uses: actions/checkout@v4
+
+      - name: Build with strict concurrency
+        run: |
+          swift build -v \
+            -Xswiftc -strict-concurrency=complete \
+            -Xswiftc -enable-actor-data-race-checks

--- a/Sources/NetworkKit/Builders/MultipartFormDataBuilder.swift
+++ b/Sources/NetworkKit/Builders/MultipartFormDataBuilder.swift
@@ -1,0 +1,118 @@
+//
+//  MultipartFormDataBuilder.swift
+//  NetworkKit
+//
+//  Created by Ahmed Mahrous on 27/12/2025.
+//
+
+import Foundation
+
+/// Builder for constructing multipart/form-data bodies
+///
+/// Used to build multipart form data for file uploads with additional fields.
+///
+/// Example:
+/// ```swift
+/// let builder = MultipartFormDataBuilder()
+///     .addTextField(named: "userId", value: "123")
+///     .addDataField(
+///         named: "file",
+///         data: fileData,
+///         mimeType: "application/pdf",
+///         filename: "document.pdf"
+///     )
+///
+/// let data = builder.build()
+/// ```
+public final class MultipartFormDataBuilder {
+    /// Boundary string for separating form parts
+    public let boundary: String
+    
+    private var bodyParts: [Data] = []
+    
+    /// Initialize with optional custom boundary
+    ///
+    /// - Parameter boundary: Custom boundary string (default: auto-generated)
+    public init(boundary: String = "Boundary-\(UUID().uuidString)") {
+        self.boundary = boundary
+    }
+    
+    /// Add a text field to the form
+    ///
+    /// - Parameters:
+    ///   - name: Field name
+    ///   - value: Field value
+    /// - Returns: Self for chaining
+    ///
+    /// Example:
+    /// ```swift
+    /// builder.addTextField(named: "username", value: "john_doe")
+    /// ```
+    @discardableResult
+    public func addTextField(named name: String, value: String) -> Self {
+        var fieldData = Data()
+        fieldData.append("--\(boundary)\r\n")
+        fieldData.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        fieldData.append("\(value)\r\n")
+        bodyParts.append(fieldData)
+        return self
+    }
+    
+    /// Add a data field (file) to the form
+    ///
+    /// - Parameters:
+    ///   - name: Field name
+    ///   - data: File data
+    ///   - mimeType: MIME type of the file
+    ///   - filename: Filename to use
+    /// - Returns: Self for chaining
+    ///
+    /// Example:
+    /// ```swift
+    /// builder.addDataField(
+    ///     named: "avatar",
+    ///     data: imageData,
+    ///     mimeType: "image/jpeg",
+    ///     filename: "avatar.jpg"
+    /// )
+    /// ```
+    @discardableResult
+    public func addDataField(
+        named name: String,
+        data: Data,
+        mimeType: String,
+        filename: String
+    ) -> Self {
+        var fieldData = Data()
+        fieldData.append("--\(boundary)\r\n")
+        fieldData.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        fieldData.append("Content-Type: \(mimeType)\r\n\r\n")
+        fieldData.append(data)
+        fieldData.append("\r\n")
+        bodyParts.append(fieldData)
+        return self
+    }
+    
+    /// Build the final multipart form data
+    ///
+    /// - Returns: Complete multipart form data
+    public func build() -> Data {
+        var body = Data()
+        
+        for part in bodyParts {
+            body.append(part)
+        }
+        
+        body.append("--\(boundary)--\r\n")
+        
+        return body
+    }
+}
+
+private extension Data {
+    mutating func append(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            append(data)
+        }
+    }
+}

--- a/Sources/NetworkKit/Builders/NetworkRequestBuilder.swift
+++ b/Sources/NetworkKit/Builders/NetworkRequestBuilder.swift
@@ -1,0 +1,220 @@
+//
+//  NetworkRequestBuilder.swift
+//  NetworkKit
+//
+//  Created by Ahmed Mahrous on 27/12/2025.
+//
+
+import Foundation
+
+/// Builder for constructing NetworkRequest instances
+///
+/// Provides a fluent API for building network requests with various
+/// encoding options (JSON, form URL encoded, multipart form data).
+///
+/// Example:
+/// ```swift
+/// let request = try NetworkRequestBuilder(url: "https://api.example.com/users")
+///     .method(.post)
+///     .header(key: "Authorization", value: "Bearer token")
+///     .jsonBody(userData)
+///     .timeout(60)
+///     .build()
+/// ```
+public final class NetworkRequestBuilder {
+    private var url: String
+    private var method: HTTPMethod = .get
+    private var headers: [String: String] = [:]
+    private var timeout: TimeInterval = 30
+    private var body: Data?
+    
+    /// Initialize builder with URL
+    ///
+    /// - Parameter url: The URL string for the request
+    public init(url: String) {
+        self.url = url
+    }
+    
+    /// Set HTTP method
+    ///
+    /// - Parameter method: HTTP method to use
+    /// - Returns: Self for chaining
+    @discardableResult
+    public func method(_ method: HTTPMethod) -> Self {
+        self.method = method
+        return self
+    }
+    
+    /// Set multiple headers at once
+    ///
+    /// - Parameter headers: Dictionary of headers
+    /// - Returns: Self for chaining
+    @discardableResult
+    public func headers(_ headers: [String: String]) -> Self {
+        self.headers = headers
+        return self
+    }
+    
+    /// Add a single header
+    ///
+    /// - Parameters:
+    ///   - key: Header field name
+    ///   - value: Header field value
+    /// - Returns: Self for chaining
+    @discardableResult
+    public func header(key: String, value: String) -> Self {
+        self.headers[key] = value
+        return self
+    }
+    
+    /// Set request timeout
+    ///
+    /// - Parameter timeout: Timeout interval in seconds
+    /// - Returns: Self for chaining
+    @discardableResult
+    public func timeout(_ timeout: TimeInterval) -> Self {
+        self.timeout = timeout
+        return self
+    }
+    
+    /// Set raw body data
+    ///
+    /// - Parameter data: Raw body data
+    /// - Returns: Self for chaining
+    @discardableResult
+    public func body(_ data: Data) -> Self {
+        self.body = data
+        return self
+    }
+    
+    /// Set JSON-encoded body
+    ///
+    /// Encodes the provided value as JSON and sets appropriate headers.
+    ///
+    /// - Parameters:
+    ///   - value: Encodable value to encode as JSON
+    ///   - encoder: JSONEncoder to use (default: JSONEncoder())
+    /// - Returns: Self for chaining
+    /// - Throws: EncodingError if encoding fails
+    ///
+    /// Example:
+    /// ```swift
+    /// struct User: Encodable {
+    ///     let name: String
+    ///     let email: String
+    /// }
+    ///
+    /// let user = User(name: "John", email: "john@example.com")
+    /// try builder.jsonBody(user)
+    /// ```
+    @discardableResult
+    public func jsonBody<T: Encodable>(_ value: T, encoder: JSONEncoder = JSONEncoder()) throws -> Self {
+        self.body = try encoder.encode(value)
+        self.headers["Content-Type"] = "application/json"
+        return self
+    }
+    
+    /// Add query parameters to URL
+    ///
+    /// Appends query parameters to the URL string.
+    ///
+    /// - Parameter parameters: Dictionary of query parameters
+    /// - Returns: Self for chaining
+    ///
+    /// Example:
+    /// ```swift
+    /// builder.queryParameters(["page": "1", "limit": "10"])
+    /// // Results in: https://api.example.com/users?limit=10&page=1
+    /// ```
+    @discardableResult
+    public func queryParameters(_ parameters: [String: String]) -> Self {
+        guard !parameters.isEmpty else { return self }
+        
+        guard var components = URLComponents(string: url) else {
+            return self
+        }
+        
+        components.queryItems = parameters.sorted(by: { $0.key < $1.key }).map {
+            URLQueryItem(name: $0.key, value: $0.value)
+        }
+        
+        if let newURL = components.url?.absoluteString {
+            self.url = newURL
+        }
+        
+        return self
+    }
+    
+    /// Set form URL encoded body
+    ///
+    /// Encodes parameters as application/x-www-form-urlencoded.
+    ///
+    /// - Parameter parameters: Form parameters
+    /// - Returns: Self for chaining
+    ///
+    /// Example:
+    /// ```swift
+    /// builder.formURLEncoded([
+    ///     "username": "john",
+    ///     "password": "secret"
+    /// ])
+    /// ```
+    @discardableResult
+    public func formURLEncoded(_ parameters: [String: String]) -> Self {
+        let encodedString = parameters
+            .sorted(by: { $0.key < $1.key })
+            .map { key, value in
+                let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+                let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+                return "\(encodedKey)=\(encodedValue)"
+            }
+            .joined(separator: "&")
+        
+        self.body = encodedString.data(using: .utf8)
+        self.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        return self
+    }
+    
+    /// Set multipart form data body
+    ///
+    /// Uses MultipartFormDataBuilder to construct multipart/form-data body.
+    ///
+    /// - Parameter builder: Closure that configures the multipart builder
+    /// - Returns: Self for chaining
+    ///
+    /// Example:
+    /// ```swift
+    /// builder.multipartFormData { multipart in
+    ///     multipart
+    ///         .addTextField(named: "name", value: "John")
+    ///         .addDataField(
+    ///             named: "avatar",
+    ///             data: imageData,
+    ///             mimeType: "image/jpeg",
+    ///             filename: "avatar.jpg"
+    ///         )
+    /// }
+    /// ```
+    @discardableResult
+    public func multipartFormData(_ builder: (MultipartFormDataBuilder) -> Void) -> Self {
+        let multipartBuilder = MultipartFormDataBuilder()
+        builder(multipartBuilder)
+        
+        self.body = multipartBuilder.build()
+        self.headers["Content-Type"] = "multipart/form-data; boundary=\(multipartBuilder.boundary)"
+        return self
+    }
+    
+    /// Build the final NetworkRequest
+    ///
+    /// - Returns: Configured NetworkRequest instance
+    public func build() -> NetworkRequest {
+        return NetworkRequest(
+            url: url,
+            method: method,
+            headers: headers,
+            body: body,
+            timeout: timeout
+        )
+    }
+}

--- a/Sources/NetworkKit/Protocols/RequestInterceptor.swift
+++ b/Sources/NetworkKit/Protocols/RequestInterceptor.swift
@@ -40,12 +40,12 @@ public protocol RequestInterceptor: Sendable {
     /// - Parameters:
     ///   - result: The result of the network request
     ///   - request: The original URLRequest
-    func didReceive(_ result: Result<NetworkResponse, Error>, for request: URLRequest) async
+    func didReceive(_ result: Result<NetworkResponse, any Error>, for request: URLRequest) async
 }
 
 /// Default implementation for didReceive (optional)
 public extension RequestInterceptor {
-    func didReceive(_ result: Result<NetworkResponse, Error>, for request: URLRequest) async {
+    func didReceive(_ result: Result<NetworkResponse, any Error>, for request: URLRequest) async {
         // Default empty implementation
     }
 }

--- a/Sources/NetworkKit/Protocols/RequestRetrier.swift
+++ b/Sources/NetworkKit/Protocols/RequestRetrier.swift
@@ -32,7 +32,7 @@ public protocol RequestRetrier: Sendable {
     ///   - error: The error that occurred
     ///   - attemptCount: Number of attempts so far (1-based)
     /// - Returns: true if request should be retried
-    func shouldRetry(request: NetworkRequest, error: Error, attemptCount: Int) -> Bool
+    func shouldRetry(request: NetworkRequest, error: any Error, attemptCount: Int) -> Bool
     
     /// Calculate delay before next retry attempt
     ///


### PR DESCRIPTION
## Description
Implements builder pattern for constructing network requests.

## Features
- 🔨 Fluent API design
- 📝 JSON body encoding
- 🔗 Query parameters
- 📋 Form URL encoding
- 📎 Multipart form data

## Example Usage
\`\`\`swift
let request = try NetworkRequestBuilder(url: \"https://api.example.com/users\")
    .method(.post)
    .jsonBody(userData)
    .header(key: \"Authorization\", value: \"Bearer token\")
    .build()
\`\`\`

## Related Issues
Closes #3

## Checklist
- [x] Builder pattern implementation
- [x] Type-safe API
- [x] Comprehensive examples
- [x] Documentation